### PR TITLE
fix #9 missing SubTypes instance

### DIFF
--- a/qc-tests/Tests.hs
+++ b/qc-tests/Tests.hs
@@ -20,8 +20,8 @@ import Test.SmartCheck.Types
 
 --------------------------------------------------------------------------------
 
-deriving instance Generic a =>  Generic (Tree a)
-instance (SubTypes a, Generic a) => SubTypes (Tree a)
+deriving instance Generic (Tree a)
+instance (SubTypes a) => SubTypes (Tree a)
 
 instance Q.Arbitrary a => Q.Arbitrary (Tree a) where
   arbitrary = Q.sized mkT

--- a/src/Test/SmartCheck/Types.hs
+++ b/src/Test/SmartCheck/Types.hs
@@ -253,10 +253,30 @@ instance (Show a, Q.Arbitrary a, SubTypes a, Typeable a) => GST (K1 i a) where
 -- http://hackage.haskell.org/packages/archive/QuickCheck/2.4.2/doc/html/Test-QuickCheck-Arbitrary.html
 
 instance SubTypes Bool    where baseType _    = True
-instance SubTypes Char    where baseType _    = True
-instance SubTypes Double  where baseType _    = True
-instance SubTypes Float   where baseType _    = True
-instance SubTypes Int     where baseType _    = True
+instance SubTypes Char where
+  subTypes _    = []
+  baseType _    = True
+  replaceChild  = replaceChild'
+  toConstr      = toConstr'
+  showForest    = showForest'
+instance SubTypes Double  where
+  subTypes _    = []
+  baseType _    = True
+  replaceChild  = replaceChild'
+  toConstr      = toConstr'
+  showForest    = showForest'
+instance SubTypes Float   where
+  subTypes _    = []
+  baseType _    = True
+  replaceChild  = replaceChild'
+  toConstr      = toConstr'
+  showForest    = showForest'
+instance SubTypes Int where
+  subTypes _    = []
+  baseType _    = True
+  replaceChild  = replaceChild'
+  toConstr      = toConstr'
+  showForest    = showForest'
 instance SubTypes Integer where
   subTypes _    = []
   baseType _    = True


### PR DESCRIPTION
not yet really familiar with you library but i think this will make it compile in newer ghc

ghc-8 does no longer export generic instance for Double, Int
but those are the same as for Word ..

make automatic deriving instance less restrictive in qc-tests
a in Tree a has only be a instance of SubTypes as far as i can tell
and it all type checks